### PR TITLE
Mithrilを使えるようにした

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": [ "es2015" ],
+  "plugins": [ "mjsx" ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 Thumbs.db
 .DS_Store
+
+# javascript build output directory
+public/javascripts

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # Rabbit Server
+
+## dev
+```sh
+$ npm run watch
+```
+
+## build
+```sh
+$ npm run build
+```

--- a/client/index.js
+++ b/client/index.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const m = require('mithril');
+
+const Home = {
+  view: () => {
+    return m('div', [
+      m('h1', 'Rabbit'),
+      m('p', 'Welcome to Rabbit')
+    ]);
+  }
+};
+
+m.route(document.getElementById('root'), '/', {
+  '/': Home
+});

--- a/client/index.js
+++ b/client/index.js
@@ -4,10 +4,10 @@ const m = require('mithril');
 
 const Home = {
   view: () => {
-    return m('div', [
-      m('h1', 'Rabbit'),
-      m('p', 'Welcome to Rabbit')
-    ]);
+    return <div>
+            <h1>Rabbit</h1>
+            <p>Welcome to Rabbit</p>
+           </div>;
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "serve-favicon": "^2.3.0"
   },
   "devDependencies": {
+    "babel-plugin-mjsx": "^4.0.0",
+    "babel-preset-es2015": "^6.3.13",
     "babelify": "^7.2.0",
     "browserify": "^12.0.1",
     "mkdirp": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,13 @@
   "main": "index.js",
   "scripts": {
     "start": "node ./bin/www",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "clean": "rimraf public/javascripts",
+    "initialize": "mkdirp public/javascripts",
+    "build:js": "browserify client/index.js -t babelify -o public/javascripts/bundle.js",
+    "build": "npm-run-all clean initialize build:*",
+    "watch:js": "watchify client/index.js -t babelify -o public/javascripts/bundle.js -v",
+    "watch": "npm-run-all clean initialize watch:*"
   },
   "repository": {
     "type": "git",
@@ -23,8 +29,16 @@
     "debug": "^2.2.0",
     "ejs": "^2.3.3",
     "express": "^4.13.3",
+    "mithril": "^0.2.0",
     "mongoose": "^4.1.6",
     "morgan": "^1.6.1",
     "serve-favicon": "^2.3.0"
+  },
+  "devDependencies": {
+    "babelify": "^7.2.0",
+    "browserify": "^12.0.1",
+    "mkdirp": "^0.5.1",
+    "npm-run-all": "^1.4.0",
+    "rimraf": "^2.4.4"
   }
 }

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -5,7 +5,7 @@
     <link rel='stylesheet' href='/stylesheets/style.css' />
   </head>
   <body>
-    <h1><%= title %></h1>
-    <p>Welcome to <%= title %></p>
+    <div id="root"></div>
+    <script src="/javascripts/bundle.js"></script>
   </body>
 </html>


### PR DESCRIPTION
`client`ディレクトリにクライアントのjsファイルを配置するようにしました。
ビルドされたjsは`public/javascripts/bundle.js`として出力されるようにしてあります。expressがブラウザに提供するのはこの`bundle.js`ファイルです。

``` sh
$ npm run build
```

でビルドできます。

``` sh
$ npm run watch
```

とすると、client/*.jsが変更になったら、差分ビルドを実行して`public/javascripts/bundle.js`を更新するようになっています。開発中はこちらを使うほうが便利です。

それと、Mithrilのviewの定義をJavaScriptソースの中にHTML風に書ける拡張(MSXといいます)も入れてあります。これもビルド時にJavaScriptのソースに変換しています。
MSXはHTML風にかけますが、HTMLとは違い閉じタグが必須(XMLと同じ)なので注意してください。
