### PR TITLE
change to unuse new operator in order to set component to router

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -8,9 +8,9 @@ const Relationships = require('./pages/relationships');
 const NewRelationship = require('./pages/relationships/new');
 
 m.route(document.getElementById('root'), '/', {
-  '/': new Home(),
-  '/children': new Children(),
-  '/children/:childId': new NewChild(),
-  '/relationships': new Relationships(),
-  '/relationships/:relationshipId': new NewRelationship()
+  '/': Home,
+  '/children': Children,
+  '/children/:childId': NewChild,
+  '/relationships': Relationships,
+  '/relationships/:relationshipId': NewRelationship
 });

--- a/client/pages/base-page.js
+++ b/client/pages/base-page.js
@@ -3,7 +3,6 @@
 const m = require('mithril');
 const pubsub = require('pubsub-js');
 const SideMenu = require('./side-menu');
-const SideMenuComponent = new SideMenu();
 
 class BasePage {
   constructor() {
@@ -23,7 +22,7 @@ class BasePage {
   view(vnode) {
     const ctrl = vnode.state;
     return <div id="layout" class={SideMenu.toggleClass([], ctrl.active)}>
-        <SideMenuComponent/>
+        <SideMenu/>
         <div id="main" onclick={ctrl.hideSideMenu}>
           {ctrl.contentView(vnode)}
         </div>


### PR DESCRIPTION
Mithril 1.1.0 から ES6 class のコンポーネントがサポートされたので`new Xxxx()`としてしのいできた部分を`Xxxx`というふうに修正した。

See https://github.com/lhorie/mithril.js/pull/1339